### PR TITLE
rename status -> exit-code

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Testo - Perl 6 Testing Done Right
     is-eqv (1, 2).Seq, (1, 2); # test fails; unlike Test.pm6's `is-deeply`
 
     # execute a program with some args and STDIN input and smartmatch its
-    # STDERR, STDOUT, and exit status:
+    # STDERR, STDOUT, and exit-code:
     is-run $*EXECUTABLE, :in<hi!>, :args['-e', 'say $*IN.uc'],
         :out(/'HI!'/), 'can say hi';
 
@@ -126,7 +126,7 @@ An optional description of the test can be specified.
         :err<42>, 'can err 42';
 
     is-run $*EXECUTABLE, :args['-e', 'die 42'],
-        :err(*), :42status, 'can exit with exit code 42';
+        :err(*), :42exit-code, 'can exit with exit code 42';
 ```
 
 **NOTE:** due to [a Rakudo bug
@@ -138,8 +138,8 @@ supplying extra args given as `:args[...]` or feeding STDIN with a `Str` or
 `Blob` data given via C<:in>.
 
 Runs three `is` tests on STDOUT, STDERR, and exit code expected values for
-which are provided via `:out`, `:err` and `:status` arguments respectively.
-If omitted, `:out` and `:err` default to empty string (`''`) and `:status`
+which are provided via `:out`, `:err` and `:exit-code` arguments respectively.
+If omitted, `:out` and `:err` default to empty string (`''`) and `:exit-code`
 defaults to `0`. Use the [Whatever star](https://docs.perl6.org/type/Whatever)
 (`*`) as the value for any of the three arguments (see `:err` in last
 example above).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Testo - Perl 6 Testing Done Right
 
     # execute a program with some args and STDIN input and smartmatch its
     # STDERR, STDOUT, and exit-code:
-    is-run $*EXECUTABLE, :in<hi!>, :args['-e', 'say $*IN.uc'],
+    runs $*EXECUTABLE, :in<hi!>, :args['-e', 'say $*IN.uc'],
         :out(/'HI!'/), 'can say hi';
 
     # run a bunch of tests as a group; like Test.pm6's `subtest`
@@ -116,16 +116,16 @@ An optional description of the test can be specified.
     is-eqv 1, 1;   # succeeds; types and values match
 ```
 
-## `is-run`
+## `runs`
 
 ```perl6
-    is-run $*EXECUTABLE, :in<hi!>, :args['-e', 'say $*IN.uc'],
+    runs $*EXECUTABLE, :in<hi!>, :args['-e', 'say $*IN.uc'],
         :out(/'HI!'/), 'can say hi';
 
-    is-run $*EXECUTABLE, :args['-e', '$*ERR.print: 42'],
+    runs $*EXECUTABLE, :args['-e', '$*ERR.print: 42'],
         :err<42>, 'can err 42';
 
-    is-run $*EXECUTABLE, :args['-e', 'die 42'],
+    runs $*EXECUTABLE, :args['-e', 'die 42'],
         :err(*), :42exit-code, 'can exit with exit code 42';
 ```
 

--- a/lib/Testo.pm6
+++ b/lib/Testo.pm6
@@ -15,7 +15,7 @@ sub group  (|c) is export {
 sub plan   (|c) is export { ($*Tester//$Tester).plan:   |c }
 sub is     (|c) is export { ($*Tester//$Tester).is:     |c }
 sub is-eqv (|c) is export { ($*Tester//$Tester).is-eqv: |c }
-sub is-run (|c) is export { ($*Tester//$Tester).is-run: |c }
+sub runs (|c) is export { ($*Tester//$Tester).runs: |c }
 
 sub done-testing (:$no-exit) is export {
     $seen-done = True;

--- a/lib/Testo/Test.pm6
+++ b/lib/Testo/Test.pm6
@@ -82,7 +82,8 @@ class IsRun does Testo::Test {
             $ = .in.close;
             my $out    = .out.slurp-rest: :close;
             my $err    = .err.slurp-rest: :close;
-            my $exit-code = .exitcode;
+            my $exit-code = .status; # until bug 130781 fixed
+            # should be.exitcode;
 
             my $wanted-exit-code = $!exit-code // 0;
             my $wanted-out    = $!out    // '';

--- a/lib/Testo/Test.pm6
+++ b/lib/Testo/Test.pm6
@@ -70,7 +70,7 @@ class IsRun does Testo::Test {
     has @.args where .all ~~ Cool;
     has $.out;
     has $.err;
-    has $.status;
+    has $.exit-code;
     has $.tester;
 
     submethod TWEAK {
@@ -82,20 +82,20 @@ class IsRun does Testo::Test {
             $ = .in.close;
             my $out    = .out.slurp-rest: :close;
             my $err    = .err.slurp-rest: :close;
-            my $status = .status;
+            my $exit-code = .exitcode;
 
-            my $wanted-status = $!status // 0;
+            my $wanted-exit-code = $!exit-code // 0;
             my $wanted-out    = $!out    // '';
             my $wanted-err    = $!err    // '';
 
             # Collapse allomorphs; needed on pre-8a0b7460e5 rakudo
-            $_ .= Str when Str for $wanted-out, $wanted-err, $wanted-status;
+            $_ .= Str when Str for $wanted-out, $wanted-err, $wanted-exit-code;
 
             my $*Tester = $!tester.new: group-level => 1+$!tester.group-level;
             $!result = $!tester.group: $*Tester, $!desc => 3 => {
                 $*Tester.is: $out,    $wanted-out,    'STDOUT';
                 $*Tester.is: $err,    $wanted-err,    'STDERR';
-                $*Tester.is: $status, $wanted-status, 'Status';
+                $*Tester.is: $exit-code, $wanted-exit-code, 'Exit-code';
             }
         }
     }

--- a/lib/Testo/Test.pm6
+++ b/lib/Testo/Test.pm6
@@ -64,7 +64,7 @@ class IsEqv does Testo::Test {
     }
 }
 
-class IsRun does Testo::Test {
+class Runs does Testo::Test {
     has Str:D $.program is required;
     has Stringy $.in;
     has @.args where .all ~~ Cool;

--- a/lib/Testo/Tester.pm6
+++ b/lib/Testo/Tester.pm6
@@ -50,12 +50,12 @@ method is-eqv (Mu $got, Mu $exp, $desc?) {
     $!out.put: $test.result
 }
 
-method is-run (
+method runs (
   Str() $program, $desc?,
   Stringy :$in, :@args, :$out, :$err, :$exit-code
   --> Testo::Test::Result:D
 ) {
-    my $test := Testo::Test::IsRun.new:
+    my $test := Testo::Test::Runs.new:
         :$program, :$desc, :$in, :@args, :$out, :$err, :$exit-code, :tester(self);
     $test.result;
 }

--- a/lib/Testo/Tester.pm6
+++ b/lib/Testo/Tester.pm6
@@ -52,11 +52,11 @@ method is-eqv (Mu $got, Mu $exp, $desc?) {
 
 method is-run (
   Str() $program, $desc?,
-  Stringy :$in, :@args, :$out, :$err, :$status
+  Stringy :$in, :@args, :$out, :$err, :$exit-code
   --> Testo::Test::Result:D
 ) {
     my $test := Testo::Test::IsRun.new:
-        :$program, :$desc, :$in, :@args, :$out, :$err, :$status, :tester(self);
+        :$program, :$desc, :$in, :@args, :$out, :$err, :$exit-code, :tester(self);
     $test.result;
 }
 

--- a/t/04-runs.t
+++ b/t/04-runs.t
@@ -3,5 +3,5 @@ use Testo;
 
 plan 1;
 
-is-run $*EXECUTABLE, :in<hi!>, :args['-e', 'say $*IN.get.uc'],
+runs $*EXECUTABLE, :in<hi!>, :args['-e', 'say $*IN.get.uc'],
     :out(/'HI!'/), :42exitcode, 'can say hi';


### PR DESCRIPTION
simple change of name. However, due to bug #130781, I have left evaluation of exit-code (line 85 as .status
